### PR TITLE
修改 JapUserService 接口中的 createAndGetHttpApiUser  方法名使其更符合语义

### DIFF
--- a/jap-core/src/main/java/com/fujieid/jap/core/JapUserService.java
+++ b/jap-core/src/main/java/com/fujieid/jap/core/JapUserService.java
@@ -39,7 +39,7 @@ public interface JapUserService {
     /**
      * Get user info by username.
      * <p>
-     * It is suitable for the {@code jap-simple} module
+     * It is suitable for {@code jap-simple} and {@code jap-http-api} module
      *
      * @param username username of the business system
      * @return JapUser
@@ -114,14 +114,14 @@ public interface JapUserService {
     }
 
     /**
-     * Save the http authed user information to the database and return JapUser
+     * Save the http authed user information to the database and return JapUser when using 'HTTP BEARER' authentication
      * <p>
      * It is suitable for the {@code jap-http-api} module
-     * @param userinfo user information
+     * @param japUser jap user information.
      * @return When saving successfully, return {@code JapUser}, otherwise return {@code null}
      */
-    default JapUser createAndGetHttpApiUser(Object userinfo){
-        return null;
+    default void saveHttpAuthedJapUser(JapUser japUser){
+
     }
 
 }

--- a/jap-http-api/src/main/java/com/fujieid/jap/httpapi/HttpApiStrategy.java
+++ b/jap-http-api/src/main/java/com/fujieid/jap/httpapi/HttpApiStrategy.java
@@ -79,7 +79,7 @@ public class HttpApiStrategy extends AbstractJapStrategy {
 
         if (authResponse != null && authResponse.isSuccess()) {
             if (config.getAuthSchema() == AuthSchemaEnum.BASIC || config.getAuthSchema() == AuthSchemaEnum.DIGEST) {
-                japUserService.createAndGetHttpApiUser(japUser);
+                japUserService.saveHttpAuthedJapUser(japUser);
             }
             return JapResponse.success(authResponse.getBody());
         } else {
@@ -259,7 +259,7 @@ public class HttpApiStrategy extends AbstractJapStrategy {
 
         // save jap user to db
         japUser.setToken(token);
-        japUserService.createAndGetHttpApiUser(japUser);
+        japUserService.saveHttpAuthedJapUser(japUser);
         return token;
     }
 


### PR DESCRIPTION
【必填】该 PR 解决了什么问题/新加了什么特性？
将修改 `JapUserService` 接口中的 `createAndGetHttpApiUser` 方法名更改为 `saveHttpAuthedJapUser` 使其更符合语义。

【必填】是否自测完成并提供了相关单元测试代码？
完成了自测，没有提供单元测试。