### PR TITLE
重构发布快照流水线

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -4,32 +4,46 @@
 name: Publish Snapshot
 
 on:
-  workflow_dispatch:
   push:
-    branches: [ dev ]
-    paths:
-      - src/**
-      - pom.xml
-  pull_request:
     branches: [ dev ]
     paths:
       - src/**
       - pom.xml
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.2.0
+
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Cache m2 package
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - run: mvn test
+
   publish:
+    needs: test
+    if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
 
-      - name: Set up Apache Maven Central
-        uses: actions/setup-java@v1
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'adopt'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -52,7 +66,7 @@ jobs:
         run: mvn versions:set -DnewVersion=${{ env.VERSION }}-SNAPSHOT
 
       - name: deploy snapshot to oss repository
-        run: mvn clean deploy -P release
+        run: mvn -B deploy -P release -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,25 @@
+name: test pull_request
+
+on: 
+  pull_request:
+    paths:
+      - src/**
+      - pom.xml
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+      - name: Cache m2 package
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - run: mvn test


### PR DESCRIPTION
重构方式与 JustAuth 一样：

1. 修复了 PR 时会发布快照的问题
2. 将 GitHub Action 中 Java 版本设置管理使用最新包