### PR TITLE
统一 SimapleConfig 时间字段类型，修复 Social 文案提示错误。

### DIFF
--- a/jap-simple/src/main/java/com/fujieid/jap/simple/SimpleConfig.java
+++ b/jap-simple/src/main/java/com/fujieid/jap/simple/SimpleConfig.java
@@ -17,6 +17,8 @@ package com.fujieid.jap.simple;
 
 import com.fujieid.jap.core.config.AuthenticateConfig;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author yadong.zhang (yadong.zhang0415(a)gmail.com)
  * @author harrylee (harryleexyz(a)qq.com)
@@ -46,7 +48,7 @@ public class SimpleConfig extends AuthenticateConfig {
     /**
      * Remember me cookie expire, unit: second, default 60*60*24*30[month]
      */
-    private Integer rememberMeCookieExpire = 2592000;
+    private Long rememberMeCookieExpire = TimeUnit.DAYS.toSeconds(30);
 
     /**
      * Remember me cookie domain
@@ -94,11 +96,11 @@ public class SimpleConfig extends AuthenticateConfig {
         return this;
     }
 
-    public Integer getRememberMeCookieExpire() {
+    public Long getRememberMeCookieExpire() {
         return rememberMeCookieExpire;
     }
 
-    public SimpleConfig setRememberMeCookieExpire(Integer rememberMeCookieExpire) {
+    public SimpleConfig setRememberMeCookieExpire(Long rememberMeCookieExpire) {
         this.rememberMeCookieExpire = rememberMeCookieExpire;
         return this;
     }

--- a/jap-simple/src/main/java/com/fujieid/jap/simple/SimpleStrategy.java
+++ b/jap-simple/src/main/java/com/fujieid/jap/simple/SimpleStrategy.java
@@ -107,7 +107,7 @@ public class SimpleStrategy extends AbstractJapStrategy {
             RequestUtil.setCookie(response,
                 simpleConfig.getRememberMeCookieKey(),
                 this.encodeCookieValue(user, simpleConfig),
-                simpleConfig.getRememberMeCookieExpire(),
+                simpleConfig.getRememberMeCookieExpire().intValue(),
                 "/",
                 cookieDomain
             );

--- a/jap-social/src/main/java/com/fujieid/jap/social/SocialStrategy.java
+++ b/jap-social/src/main/java/com/fujieid/jap/social/SocialStrategy.java
@@ -324,10 +324,10 @@ public class SocialStrategy extends AbstractJapStrategy {
         try {
             authUserAuthResponse = authRequest.revoke(authToken);
         } catch (Exception e) {
-            throw new JapSocialException("Third party refresh access token of `" + source + "` failed. " + e.getMessage());
+            throw new JapSocialException("Third party revoke access token of `" + source + "` failed. " + e.getMessage());
         }
         if (!authUserAuthResponse.ok() || ObjectUtil.isNull(authUserAuthResponse.getData())) {
-            throw new JapUserException("Third party refresh access token of `" + source + "` failed. " + authUserAuthResponse.getMsg());
+            throw new JapUserException("Third party revoke access token of `" + source + "` failed. " + authUserAuthResponse.getMsg());
         }
 
         return JapResponse.success();


### PR DESCRIPTION
> Notes: Please make sure that the code you contributed **does not have protocol conflicts/incompatibility**
>
> You can check your code from the following two aspects:
> - Has a third-party dependency library been added? If a third-party dependent library is added, is its license compatible with LGPL-3.0? (License compatible, please refer to:[开源许可证兼容性指南 - 使用库的兼容性列表](https://shimo.im/docs/uL4VQaYGL2sadQOV#anchor-74ae))
> - Have you referenced/borrowed/copied the code of other open source projects? Is the license of the project to which the referenced code belongs compatible with LGPL-3.0? (License compatible, please refer to:[开源许可证兼容性指南 - 合并/修改代码的许可证兼容性列表](https://shimo.im/docs/uL4VQaYGL2sadQOV#anchor-39f8))
>
> If your code or newly introduced dependencies in the code are not compatible with LGPL-3.0, **we may not merge your code**.


## What this PR does / why we need it:
同步 SimapleConfig 类与 JapConfig 中时间字段使用一致。

Jap 整个系统中时间类型应该统一，有些地方 Integer 有些地方 Lone 用户需要转换。

## Pre-submission checklist:
- [x] Did you explain what problem does this PR solve?
- [ ] What new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible?




